### PR TITLE
Raising PageNotFoundError

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
   fast_finish: true
   allow_failures:
   - python: "nightly"
+  - python: "3.2"
 python:
   - "2.6"
   - "2.7"

--- a/haralyzer/assets.py
+++ b/haralyzer/assets.py
@@ -11,7 +11,8 @@ import numpy
 assert parser
 import re
 
-from haralyzer.compat import iteritems
+from .compat import iteritems
+from .errors import PageNotFoundError
 
 
 DECIMAL_PRECISION = 0
@@ -351,6 +352,15 @@ class HarPage(object):
                 self.title = page['title']
                 self.startedDateTime = page['startedDateTime']
                 self.pageTimings = page['pageTimings']
+
+        if not getattr(self, 'title', None):
+            raise PageNotFoundError(
+                'No page found with id {0}\n\nValid pages are {1}'.format(
+                    self.page_id, self.parser.pages)
+            )
+
+    def __repr__(self):
+        return 'ID: {0}, URL: {1}'.format(self.page_id, self.url)
 
     def _get_asset_files(self, asset_type):
         """

--- a/haralyzer/errors.py
+++ b/haralyzer/errors.py
@@ -1,0 +1,7 @@
+"""
+Custom exceptions for good ol haralyzer.
+"""
+
+
+class PageNotFoundError(AttributeError):
+    pass

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -2,8 +2,10 @@ import dateutil
 import pytest
 from haralyzer import HarPage, HarParser
 from haralyzer.compat import iteritems
+from haralyzer.errors import PageNotFoundError
 import re
 
+BAD_PAGE_ID = 'sup_dawg'
 PAGE_ID = 'page_3'
 
 
@@ -14,8 +16,13 @@ def test_init(har_data):
     with pytest.raises(ValueError):
         page = HarPage(PAGE_ID)
 
-    # Make sure it can load with either har_data or a parser
     init_data = har_data('humanssuck.net.har')
+
+    # Throws PageNotFoundException with bad page ID
+    with pytest.raises(PageNotFoundError):
+        page = HarPage(BAD_PAGE_ID, har_data=init_data)
+
+    # Make sure it can load with either har_data or a parser
     page = HarPage(PAGE_ID, har_data=init_data)
     assert isinstance(page, HarPage)
     parser = HarParser(init_data)


### PR DESCRIPTION
When initializing the `HarPage` object, it would initialize happily with a bad page ID, causing weird errors later on when you actually try to use it. It will now raise the `PageNotFoundError` during initialization instead. 

Addresses #9 