### PR TITLE
Fix 'unsupported operand type' error in time_to_first_byte method

### DIFF
--- a/haralyzer/assets.py
+++ b/haralyzer/assets.py
@@ -407,7 +407,7 @@ class HarPage(object):
         initial_entry = self.entries[0]
         ttfb = 0
         for k, v in iteritems(initial_entry['timings']):
-            if k != 'receive':
+            if k != 'receive' and isinstance(v, int)
                 ttfb += v
         return ttfb
 


### PR DESCRIPTION
When I use `har_page.time_to_first_byte`method I get this error:

```
File "/usr/local/lib/python3.5/site-packages/cached_property.py", line 26, in __get__
  value = obj.__dict__[self.func.__name__] = self.func(obj)
File "/usr/local/lib/python3.5/site-packages/haralyzer/assets.py", line 416, in time_to_first_byte
  if k != 'receive':
TypeError: unsupported operand type(s) for +=: 'int' and 'str'
```
I have solved the problem adding a condition to verify that only the numerical variables are acumulated with the `+=` operator.