### PR TITLE
make setting of title optional since current Firefox Inspector might not put one in the saved har file

### DIFF
--- a/haralyzer/assets.py
+++ b/haralyzer/assets.py
@@ -243,7 +243,8 @@ class HarPage(object):
         for page in raw_data['pages']:
             if page['id'] == self.page_id:
                 valid = True
-                self.title = page['title']
+                if 'title' in page:
+                    self.title = page['title']
                 self.startedDateTime = page['startedDateTime']
                 self.pageTimings = page['pageTimings']
 


### PR DESCRIPTION
Some time prior to Firefox 67.0.4 [currently using 68.0.1 (64-bit)], using the Inspector Network pane to record a session and save it as a HAR file stopped including a "title" element in the "pages" section.  Make setting of title in the haralyzer data first check for existence of the "title" item before trying to set it to avert a "KeyError: 'title'" failure.