### PR TITLE
Find duplicate requests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -99,7 +99,7 @@ file (see example above) with `har_data=har_data`::
 
     # Get duplicate requests if any
     har_page.duplicate_url_request
-    # Returns a list of urls if any request is made more than once
+    # Returns a dict of urls and its number of repetitions if any request is made more than once
 
     # Get the transferred sizes (works only with HAR files, generated with Chrome)
     har_page.page_size_trans

--- a/README.rst
+++ b/README.rst
@@ -97,6 +97,10 @@ file (see example above) with `har_data=har_data`::
     # prints 733488
     # We could do this with 'css', 'js', 'html', 'audio', or 'video'
 
+    # Get duplicate requests if any
+    har_page.duplicate_url_request
+    # Returns a list of urls if any request is made more than once
+
     # Get the transferred sizes (works only with HAR files, generated with Chrome)
     har_page.page_size_trans
     har_page.image_size_trans

--- a/haralyzer/assets.py
+++ b/haralyzer/assets.py
@@ -494,6 +494,26 @@ class HarPage(object):
                             entry['response']['status'] <= 399):
                 return entry
 
+    @cached_property
+    def duplicate_url_request(self):
+        """
+        Returns a list of urls that are sent more than once
+        """
+
+        urls = {}
+        url_list = []
+        for entry in self.entries:
+            url = entry.get('request').get('url')
+            if urls.get(url) is None:
+                urls.update({url: 1})
+            else:
+                urls.update({url: urls.get(url) + 1})
+
+        for url, count in urls.items():
+            if count > 1:
+                url_list.append(url)
+        return url_list
+
     # Convenience properties. Easy accessible through the API, but even easier
     # to use as properties
     @cached_property

--- a/haralyzer/assets.py
+++ b/haralyzer/assets.py
@@ -497,11 +497,11 @@ class HarPage(object):
     @cached_property
     def duplicate_url_request(self):
         """
-        Returns a list of urls that are sent more than once
+        Returns a dict of urls and its number of repetitions that are sent more than once
         """
 
         urls = {}
-        url_list = []
+        url_list1 = {}
         for entry in self.entries:
             url = entry.get('request').get('url')
             if urls.get(url) is None:
@@ -511,8 +511,8 @@ class HarPage(object):
 
         for url, count in urls.items():
             if count > 1:
-                url_list.append(url)
-        return url_list
+                url_list1.update({url:count})
+        return url_list1
 
     # Convenience properties. Easy accessible through the API, but even easier
     # to use as properties

--- a/tests/data/humanssuck.net_duplicate_url.har
+++ b/tests/data/humanssuck.net_duplicate_url.har
@@ -1,0 +1,596 @@
+{
+  "log": {
+    "pages": [
+      {
+        "id": "page_3",
+        "startedDateTime": "2015-02-22T19:28:12.136-08:00",
+        "pageTimings": {
+          "onLoad": 567,
+          "onContentLoad": 543
+        },
+        "title": "http://humanssuck.net/"
+      }
+    ],
+    "browser": {
+      "version": "25.0.1",
+      "name": "Firefox"
+    },
+    "entries": [
+      {
+        "serverIPAddress": "216.70.110.121",
+        "cache": {},
+        "startedDateTime": "2015-02-22T19:28:12.136-08:00",
+        "pageref": "page_3",
+        "request": {
+          "cookies": [],
+          "url": "http://humanssuck.net/",
+          "queryString": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "humanssuck.net"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 292,
+          "bodySize": -1,
+          "method": "GET",
+          "httpVersion": "HTTP/1.1"
+        },
+        "timings": {
+          "receive": 0,
+          "send": 0,
+          "connect": 0,
+          "dns": 0,
+          "wait": 76,
+          "blocked": 77
+        },
+        "connection": "80",
+        "time": 153,
+        "response": {
+          "status": 200,
+          "cookies": [],
+          "statusText": "OK",
+          "content": {
+            "mimeType": "text/html",
+            "text": "<!DOCTYPE HTML>\n<html>\r\n<head>humanssuck.net\n<link rel=\"stylesheet\" type=\"text/css\" href=\"test.css\"></head>\r\n<body>\r\n<img src=\"screen_login.gif\">\n<script src=\"jquery-1.7.1.min.js\"></script>\n<video width=\"320\" height=\"240\" controls>\n\t<source src=\"test_video.mp4\" type=\"video/mp4\">\n</video>\n</body>\r\n</html>\r\n\n",
+            "size": 308
+          },
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 23 Feb 2015 03:28:12 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/html; charset=UTF-8"
+            },
+            {
+              "name": "Transfer-Encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "X-Accel-Version",
+              "value": "0.01"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Mon, 23 Feb 2015 03:22:35 GMT"
+            },
+            {
+              "name": "Etag",
+              "value": "\"3e20f0c-134-50fb8e9e3f6be\""
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "PleskLin"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 338,
+          "redirectURL": "",
+          "bodySize": 238,
+          "httpVersion": "HTTP/1.1"
+        }
+      },
+      {
+        "serverIPAddress": "216.70.110.121",
+        "cache": {},
+        "startedDateTime": "2015-02-22T19:28:12.319-08:00",
+        "pageref": "page_3",
+        "request": {
+          "cookies": [],
+          "url": "http://humanssuck.net/test.css",
+          "queryString": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "humanssuck.net"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
+            },
+            {
+              "name": "Accept",
+              "value": "text/css,*/*;q=0.1"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Referer",
+              "value": "http://humanssuck.net/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 288,
+          "bodySize": -1,
+          "method": "GET",
+          "httpVersion": "HTTP/1.1"
+        },
+        "timings": {
+          "receive": 0,
+          "send": 0,
+          "connect": 0,
+          "dns": 0,
+          "wait": 76,
+          "blocked": 0
+        },
+        "connection": "80",
+        "time": 76,
+        "response": {
+          "status": 200,
+          "cookies": [],
+          "statusText": "OK",
+          "content": {
+            "mimeType": "text/css",
+            "text": "testing\n",
+            "size": 8
+          },
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 23 Feb 2015 03:28:12 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "text/css"
+            },
+            {
+              "name": "Content-Length",
+              "value": "8"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "X-Accel-Version",
+              "value": "0.01"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Tue, 22 Jan 2013 08:05:08 GMT"
+            },
+            {
+              "name": "Etag",
+              "value": "\"3e21423-8-4d3dc093b7500\""
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=2592000"
+            },
+            {
+              "name": "Expires",
+              "value": "Wed, 25 Mar 2015 03:28:12 GMT"
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "PleskLin"
+            }
+          ],
+          "headersSize": 358,
+          "redirectURL": "",
+          "bodySize": 8,
+          "httpVersion": "HTTP/1.1"
+        }
+      },
+      {
+        "serverIPAddress": "216.70.110.121",
+        "cache": {},
+        "startedDateTime": "2015-02-22T19:28:12.319-08:00",
+        "pageref": "page_3",
+        "request": {
+          "cookies": [],
+          "url": "http://humanssuck.net/screen_login.gif",
+          "queryString": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "humanssuck.net"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
+            },
+            {
+              "name": "Accept",
+              "value": "image/png,image/*;q=0.8,*/*;q=0.5"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Referer",
+              "value": "http://humanssuck.net/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 311,
+          "bodySize": -1,
+          "method": "GET",
+          "httpVersion": "HTTP/1.1"
+        },
+        "timings": {
+          "receive": 75,
+          "send": 0,
+          "connect": 76,
+          "dns": 0,
+          "wait": 76,
+          "blocked": 77
+        },
+        "connection": "80",
+        "time": 304,
+        "response": {
+          "status": 200,
+          "cookies": [],
+          "statusText": "OK",
+          "content": {
+            "mimeType": "image/gif",
+            "size": 23591
+          },
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 23 Feb 2015 03:28:12 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "image/gif"
+            },
+            {
+              "name": "Content-Length",
+              "value": "23591"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Mon, 23 Feb 2015 03:14:47 GMT"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=31536000"
+            },
+            {
+              "name": "Expires",
+              "value": "Tue, 23 Feb 2016 03:28:12 GMT"
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "PleskLin"
+            },
+            {
+              "name": "Accept-Ranges",
+              "value": "bytes"
+            }
+          ],
+          "headersSize": 308,
+          "redirectURL": "",
+          "bodySize": 23591,
+          "httpVersion": "HTTP/1.1"
+        }
+      },
+      {
+        "serverIPAddress": "216.70.110.121",
+        "cache": {},
+        "startedDateTime": "2015-02-22T19:28:12.319-08:00",
+        "pageref": "page_3",
+        "request": {
+          "cookies": [],
+          "url": "http://humanssuck.net/jquery-1.7.1.min.js",
+          "queryString": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "humanssuck.net"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
+            },
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Referer",
+              "value": "http://humanssuck.net/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 284,
+          "bodySize": -1,
+          "method": "GET",
+          "httpVersion": "HTTP/1.1"
+        },
+        "timings": {
+          "receive": 152,
+          "send": 0,
+          "connect": 0,
+          "dns": 0,
+          "wait": 81,
+          "blocked": 77
+        },
+        "connection": "80",
+        "time": 310,
+        "response": {
+          "status": 200,
+          "cookies": [],
+          "statusText": "OK",
+          "content": {
+            "mimeType": "application/x-javascript",
+            "text": "/*! jQuery v1.7.1 jquery.com | jquery.org/license */\n(function(a,b){function cy(a){return f.isWindow(a)?a:a.nodeType===9?a.defaultView||a.parentWindow:!1}function cv(a){if(!ck[a]){var b=c.body,d=f(\"<\"+a+\">\").appendTo(b),e=d.css(\"display\");d.remove();if(e===\"none\"||e===\"\"){cl||(cl=c.createElement(\"iframe\"),cl.frameBorder=cl.width=cl.height=0),b.appendChild(cl);if(!cm||!cl.createElement)cm=(cl.contentWindow||cl.contentDocument).document,cm.write((c.compatMode===\"CSS1Compat\"?\"<!doctype html>\":\"\")+\"<html><body>\"),cm.close();d=cm.createElement(a),cm.body.appendChild(d),e=f.css(d,\"display\"),b.removeChild(cl)}ck[a]=e}return ck[a]}function cu(a,b){var c={};f.each(cq.concat.apply([],cq.slice(0,b)),function(){c[this]=a});return c}function ct(){cr=b}function cs(){setTimeout(ct,0);return cr=f.now()}function cj(){try{return new a.ActiveXObject(\"Microsoft.XMLHTTP\")}catch(b){}}function ci(){try{return new a.XMLHttpRequest}catch(b){}}function cc(a,c){a.dataFilter&&(c=a.dataFilter(c,a.dataType));var d=a.dataTypes,e={},g,h,i=d... [truncated to save space (92843 more bytes)]",
+            "size": 93867
+          },
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 23 Feb 2015 03:28:12 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/x-javascript"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Mon, 23 Feb 2015 03:16:00 GMT"
+            },
+            {
+              "name": "Transfer-Encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=2592000"
+            },
+            {
+              "name": "Expires",
+              "value": "Wed, 25 Mar 2015 03:28:12 GMT"
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "PleskLin"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 352,
+          "redirectURL": "",
+          "bodySize": 38367,
+          "httpVersion": "HTTP/1.1"
+        }
+      },
+      {
+        "serverIPAddress": "216.70.110.121",
+        "cache": {},
+        "startedDateTime": "2015-02-22T19:28:12.319-08:00",
+        "pageref": "page_3",
+        "request": {
+          "cookies": [],
+          "url": "http://humanssuck.net/jquery-1.7.1.min.js",
+          "queryString": [],
+          "headers": [
+            {
+              "name": "Host",
+              "value": "humanssuck.net"
+            },
+            {
+              "name": "User-Agent",
+              "value": "Mozilla/5.0 (X11; Linux i686 on x86_64; rv:25.0) Gecko/20100101 Firefox/25.0"
+            },
+            {
+              "name": "Accept",
+              "value": "*/*"
+            },
+            {
+              "name": "Accept-Language",
+              "value": "en-US,en;q=0.5"
+            },
+            {
+              "name": "Accept-Encoding",
+              "value": "gzip, deflate"
+            },
+            {
+              "name": "Referer",
+              "value": "http://humanssuck.net/"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            }
+          ],
+          "headersSize": 284,
+          "bodySize": -1,
+          "method": "GET",
+          "httpVersion": "HTTP/1.1"
+        },
+        "timings": {
+          "receive": 152,
+          "send": 0,
+          "connect": 0,
+          "dns": 0,
+          "wait": 81,
+          "blocked": 77
+        },
+        "connection": "80",
+        "time": 310,
+        "response": {
+          "status": 200,
+          "cookies": [],
+          "statusText": "OK",
+          "content": {
+            "mimeType": "application/x-javascript",
+            "text": "/*! jQuery v1.7.1 jquery.com | jquery.org/license */\n(function(a,b){function cy(a){return f.isWindow(a)?a:a.nodeType===9?a.defaultView||a.parentWindow:!1}function cv(a){if(!ck[a]){var b=c.body,d=f(\"<\"+a+\">\").appendTo(b),e=d.css(\"display\");d.remove();if(e===\"none\"||e===\"\"){cl||(cl=c.createElement(\"iframe\"),cl.frameBorder=cl.width=cl.height=0),b.appendChild(cl);if(!cm||!cl.createElement)cm=(cl.contentWindow||cl.contentDocument).document,cm.write((c.compatMode===\"CSS1Compat\"?\"<!doctype html>\":\"\")+\"<html><body>\"),cm.close();d=cm.createElement(a),cm.body.appendChild(d),e=f.css(d,\"display\"),b.removeChild(cl)}ck[a]=e}return ck[a]}function cu(a,b){var c={};f.each(cq.concat.apply([],cq.slice(0,b)),function(){c[this]=a});return c}function ct(){cr=b}function cs(){setTimeout(ct,0);return cr=f.now()}function cj(){try{return new a.ActiveXObject(\"Microsoft.XMLHTTP\")}catch(b){}}function ci(){try{return new a.XMLHttpRequest}catch(b){}}function cc(a,c){a.dataFilter&&(c=a.dataFilter(c,a.dataType));var d=a.dataTypes,e={},g,h,i=d... [truncated to save space (92843 more bytes)]",
+            "size": 93867
+          },
+          "headers": [
+            {
+              "name": "Server",
+              "value": "nginx"
+            },
+            {
+              "name": "Date",
+              "value": "Mon, 23 Feb 2015 03:28:12 GMT"
+            },
+            {
+              "name": "Content-Type",
+              "value": "application/x-javascript"
+            },
+            {
+              "name": "Last-Modified",
+              "value": "Mon, 23 Feb 2015 03:16:00 GMT"
+            },
+            {
+              "name": "Transfer-Encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "Connection",
+              "value": "keep-alive"
+            },
+            {
+              "name": "Vary",
+              "value": "Accept-Encoding"
+            },
+            {
+              "name": "Cache-Control",
+              "value": "max-age=2592000"
+            },
+            {
+              "name": "Expires",
+              "value": "Wed, 25 Mar 2015 03:28:12 GMT"
+            },
+            {
+              "name": "X-Powered-By",
+              "value": "PleskLin"
+            },
+            {
+              "name": "Content-Encoding",
+              "value": "gzip"
+            }
+          ],
+          "headersSize": 352,
+          "redirectURL": "",
+          "bodySize": 38367,
+          "httpVersion": "HTTP/1.1"
+        }
+      }
+    ],
+    "version": "1.1",
+    "creator": {
+      "version": "1.12",
+      "name": "Firebug"
+    }
+  }
+}

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -224,4 +224,4 @@ def test_duplicate_urls_count(har_data):
     """
     init_data = har_data('humanssuck.net_duplicate_url.har')
     page = HarPage(PAGE_ID, har_data=init_data)
-    assert len(page.duplicate_url_request)==1
+    assert len(page.duplicate_url_request.keys())==1

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -218,7 +218,7 @@ def _correct_file_type(entry, file_types):
             return any(ft in header['value'] for ft in file_types)
 
 
-def validate_duplicate_urls_count(har_data):
+def test_duplicate_urls_count(har_data):
     """
     Makes sure that the correct number of urls that appear more than once in har is displayed.
     """

--- a/tests/test_page.py
+++ b/tests/test_page.py
@@ -216,3 +216,12 @@ def _correct_file_type(entry, file_types):
     for header in entry['response']['headers']:
         if header['name'] == 'Content-Type':
             return any(ft in header['value'] for ft in file_types)
+
+
+def validate_duplicate_urls_count(har_data):
+    """
+    Makes sure that the correct number of urls that appear more than once in har is displayed.
+    """
+    init_data = har_data('humanssuck.net_duplicate_url.har')
+    page = HarPage(PAGE_ID, har_data=init_data)
+    assert len(page.duplicate_url_request)==1


### PR DESCRIPTION
- **Added a new method** to get `a list of urls of the requests that are sent more than once`
- **Returning the list of urls** that are repeated more than once in the HAR file
- **Added a new HAR file** 'http://humanssuck.net/jquery-1.7.1.min.js' request twice
- **Added a test** to verify the length of the list returned by the new method on the above HAR file is 1
- This is very useful **whenever an external plugin** (ex. in the case of lazy loading) t**hat sends the requests more than once**.