### PR TITLE
filter_entries() w/ content_type ignores entries with no mimeType instead of crashing

### DIFF
--- a/haralyzer/assets.py
+++ b/haralyzer/assets.py
@@ -77,12 +77,17 @@ class HarParser(object):
     def match_content_type(entry, content_type, regex=True):
         """
         Matches the content type of a request using the mimeType metadata.
+        Entries with no mimeType are filtered out.
 
         :param entry: ``dict`` of a single entry from a HarPage
         :param content_type: ``str`` of regex to use for finding content type
         :param regex: ``bool`` indicating whether to use regex or exact match.
         """
-        mimeType = entry['response']['content']['mimeType']
+        content = entry['response']['content']
+        if 'mimeType' not in content:
+        	return False
+
+        mimeType = content['mimeType']
 
         if regex and re.search(content_type, mimeType, flags=re.IGNORECASE):
             return True


### PR DESCRIPTION
match_content_type checks if mimeType exists in an entry before trying to access it, and does not match if it doesn't find it.